### PR TITLE
Blog app - API documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,3 +77,5 @@ gem 'will_paginate', '~> 3.3'
 gem 'cancancan'
 
 gem 'jwt'
+
+gem 'rswag'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -127,6 +127,8 @@ GEM
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
+    json-schema (4.1.1)
+      addressable (>= 2.8)
     jwt (2.7.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -233,6 +235,21 @@ GEM
       rspec-mocks (~> 3.10)
       rspec-support (~> 3.10)
     rspec-support (3.12.1)
+    rswag (2.13.0)
+      rswag-api (= 2.13.0)
+      rswag-specs (= 2.13.0)
+      rswag-ui (= 2.13.0)
+    rswag-api (2.13.0)
+      activesupport (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
+    rswag-specs (2.13.0)
+      activesupport (>= 3.1, < 7.2)
+      json-schema (>= 2.2, < 5.0)
+      railties (>= 3.1, < 7.2)
+      rspec-core (>= 2.14)
+    rswag-ui (2.13.0)
+      actionpack (>= 3.1, < 7.2)
+      railties (>= 3.1, < 7.2)
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     selenium-webdriver (4.16.0)
@@ -295,6 +312,7 @@ DEPENDENCIES
   rails (~> 7.1.2)
   rails-controller-testing
   rspec-rails
+  rswag
   selenium-webdriver
   sprockets-rails
   stimulus-rails


### PR DESCRIPTION
1. Write the API integration specs using [rswag](https://github.com/rswag/rswag#getting-started) for your existing endpoints.
2. Generate the documentation.